### PR TITLE
Add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to npm
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Publish package
+        run: npm publish


### PR DESCRIPTION
### Motivation

Publish `el-input-tag` to npm directly from GitHub Releases without storing a long-lived npm token in GitHub Secrets.

### Description

- Added `.github/workflows/publish.yml`.
- The workflow runs when a GitHub Release is published.
- It uses npm Trusted Publishing via GitHub Actions OIDC.
- It grants `id-token: write` and `contents: read` permissions.
- It installs dependencies, runs tests, verifies package contents with `npm pack --dry-run`, then runs `npm publish`.

### Manual setup required before publishing

Configure npm Trusted Publisher for this package on npmjs.com:

- Package: `el-input-tag`
- Provider: GitHub Actions
- Organization or user: `xiispace`
- Repository: `el-input-tag`
- Workflow filename: `publish.yml`
- Environment name: `npm-publish`
- Allowed actions: `npm publish`

Optional but recommended in GitHub:

- Create the `npm-publish` environment under repository settings.
- Add required reviewers for that environment if you want a manual approval gate before npm publish.

### Release flow after setup

1. Bump `package.json` version, for example `1.3.3` -> `1.4.0`.
2. Merge the version bump.
3. Create and publish a GitHub Release with matching tag, for example `v1.4.0`.
4. The publish workflow will run tests and publish to npm.